### PR TITLE
feat(blog-2022): 블로그 상세페이지 queryString으로 컨텐츠 가져오도록 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
         <Routes>
           <Route path="/" element={<MainLayout />}>
             <Route path="/" element={<Posts />} />
-            <Route path="/:id" element={<PostDetail />} />
+            <Route path="/posts/detail" element={<PostDetail />} />
             <Route path="/tags" element={<Tags />} />
             <Route path="/portpolio" element={<Portpolio />} />
             <Route path="/about" element={<About />} />

--- a/src/components/molecules/posts/PostCard.tsx
+++ b/src/components/molecules/posts/PostCard.tsx
@@ -27,11 +27,11 @@ export default function PostCard(props: IPostCard) {
     return `${year}.${month}.${day}`;
   };
 
-  const getPathName = () => fileName.substring(0, fileName.length - 3);
+  const getPathName = () => fileName.replace('.md', '');
 
   return (
     <PostCardItem>
-      <Link to={`/${getPathName()}`}>
+      <Link to={`/posts/detail?id=${getPathName()}`}>
         <CardTitle>{title}</CardTitle>
       </Link>
       <CardAuthor>

--- a/src/pages/Posts.tsx
+++ b/src/pages/Posts.tsx
@@ -4,16 +4,17 @@ import styled from '@emotion/styled';
 import { useLocation } from 'react-router-dom';
 import { useAtom } from 'jotai';
 import { filteredPostsAtom, pagePostAtom, postsAtom } from '@store/posts';
+import { getQueryString } from '@utils/Utility';
 
 // components
 import Text from '@components/atoms/Text';
 import Search from '@components/molecules/posts/Search';
 import PostContents from '@components/molecules/posts/PostContents';
 
+// interfaces
 interface IQueryString {
   search?: string;
 }
-
 export default function Posts() {
   const location = useLocation();
   const [posts] = useAtom(postsAtom);
@@ -21,19 +22,6 @@ export default function Posts() {
   const [filteredPosts] = useAtom(filteredPostsAtom);
 
   const [searchInput, setSearchInput] = useState<string>('');
-
-  const getQueryString = (search: string) => {
-    const queryString = search.substring(1);
-    let queryInstance: IQueryString = {};
-
-    queryString.split('&').forEach((query) => {
-      const key = query.split('=')[0];
-      const value = query.split('=')[1];
-      queryInstance[key] = decodeURIComponent(value);
-    });
-
-    return queryInstance;
-  };
 
   const title = useMemo(() => (searchInput.length === 0 ? 'Post' : 'Search Result'), [searchInput]);
   const contentsData = useMemo(
@@ -43,7 +31,7 @@ export default function Posts() {
 
   // 쿼리스트링 처리
   useEffect(() => {
-    const queryInstance = getQueryString(location.search);
+    const queryInstance: IQueryString = getQueryString(location.search);
     if (queryInstance?.search) {
       setSearchInput(queryInstance?.search);
     }

--- a/src/utils/Utility.tsx
+++ b/src/utils/Utility.tsx
@@ -1,3 +1,7 @@
+type IQueryString = {
+  [key: string]: string;
+};
+
 // Date 변환
 export const getDateFormat = (value: string): string => {
   const d = new Date(value);
@@ -13,4 +17,17 @@ export const getDateFormat = (value: string): string => {
   }
 
   return year + month + day;
+};
+
+export const getQueryString = (search: string) => {
+  const queryString = search.substring(1);
+  let queryInstance: IQueryString = {};
+
+  queryString.split('&').forEach((query) => {
+    const key = query.split('=')[0];
+    const value = query.split('=')[1];
+    queryInstance[key] = decodeURIComponent(value);
+  });
+
+  return queryInstance;
 };


### PR DESCRIPTION
# 블로그 상세페이지 queryString으로 컨텐츠 가져오도록 변경

### 개발내용

- SPA 라우팅을 고려하지 않고 개발하여 path를 인식하지 못하는 현상 발생
  - reload가 먹히지 않음
  - 라우팅 하나를 추가 (posts/detail)
  - /post/detail에 query string id를 전달하여 id값을 읽어오고, posts 파일을 get api로 호출하는 방식으로 변경

- query string 경로 변경
  - query string 이 posts 컴포넌트 내에 의존성을 갖게 됐던 것을 util함수로 이전
  - 공통 유틸로 사용할 수 있도록 변경

